### PR TITLE
OMSCRUM-475: bump ox dependency

### DIFF
--- a/address_validate.gemspec
+++ b/address_validate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency "ox", "~> 2.4.1"
+  spec.add_dependency "ox", "~> 2.14.6"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/address_validate/version.rb
+++ b/lib/address_validate/version.rb
@@ -1,3 +1,3 @@
 module AddressValidate
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Updates `ox` to fix a security issue.